### PR TITLE
Fix README and push command for TrustyAI image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,7 @@ push-ubi9-py39:
 	podman push localhost/workbench-images:jupyter-datascience-ubi9-py39_${RELEASE}_${DATE} ${REPO}:jupyter-datascience-ubi9-py39_${RELEASE}_${DATE}
 	podman push localhost/workbench-images:jupyter-minimal-ubi9-py39_${RELEASE}_${DATE} ${REPO}:jupyter-minimal-ubi9-py39_${RELEASE}_${DATE}
 	podman push localhost/workbench-images:jupyter-optapy-ubi9-py39_${RELEASE}_${DATE} ${REPO}:jupyter-optapy-ubi9-py39_${RELEASE}_${DATE}
+	podman push localhost/workbench-images:jupyter-trustyai-ubi9-py39_${RELEASE}_${DATE} ${REPO}:jupyter-trustyai-ubi9-py39_${RELEASE}_${DATE}
 	podman push localhost/workbench-images:jupyter-spark-ubi9-py39_${RELEASE}_${DATE} ${REPO}:jupyter-spark-ubi9-py39_${RELEASE}_${DATE}
 # Push latest tag to all new images	
 	podman push localhost/workbench-images:base-ubi9-py39_${RELEASE}_${DATE} ${REPO}:base-ubi9-py39_${RELEASE}_latest
@@ -119,7 +120,7 @@ push-ubi9-py39:
 	podman push localhost/workbench-images:jupyter-datascience-code-server-ubi9-py39_${RELEASE}_${DATE} ${REPO}:jupyter-datascience-code-server-ubi9-py39_${RELEASE}_latest
 	podman push localhost/workbench-images:jupyter-datascience-ubi9-py39_${RELEASE}_${DATE} ${REPO}:jupyter-datascience-ubi9-py39_${RELEASE}_latest
 	podman push localhost/workbench-images:jupyter-minimal-ubi9-py39_${RELEASE}_${DATE} ${REPO}:jupyter-minimal-ubi9-py39_${RELEASE}_latest
-	podman push localhost/workbench-images:jupyter-optapy-ubi9-py39_${RELEASE}_${DATE} ${REPO}:jupyter-optapy-ubi9-py39_${RELEASE}_latest
+	podman push localhost/workbench-images:jupyter-trustyai-ubi9-py39_${RELEASE}_${DATE} ${REPO}:jupyter-trustyai-ubi9-py39_${RELEASE}_latest
 	podman push localhost/workbench-images:jupyter-spark-ubi9-py39_${RELEASE}_${DATE} ${REPO}:jupyter-spark-ubi9-py39_${RELEASE}_latest
 
 

--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ CUDA 11.8 + CuDNN 8.6.0 versions:
 
 ### Specialty images
 
-| Image description | Pull address |
-|-------------------|--------------|
-|[Spark/PySpark 3.3.1 with Hadoop 3.3.4 based on jupyter-datascience-ubi9-py39](https://quay.io/opendatahub-contrib/workbench-images:jupyter-spark-ubi9-py39_2023b_latest)|quay.io/opendatahub-contrib/workbench-images:jupyter-spark-ubi9-py39_2023b_latest|
-|[OptaPy based on jupyter-datascience-ubi9-py39](https://quay.io/opendatahub-contrib/workbench-images:jupyter-optapy-ubi9-py39_2023b_latest)|quay.io/opendatahub-contrib/workbench-images:jupyter-optapy-ubi9-py39_2023b_latest|
-|[TrustyAI based on jupyter-datascience-ubi9-py39](https://quay.io/opendatahub-contrib/workbench-images:jupyter-trustyai-ubi9-py39_2023b_latest)|quay.io/opendatahub-contrib/workbench-images:jupyter-monai-c9s-py39_2023b_latest|
-|[Monai JupyterLab Notebook image on Centos Stream 9 with Python 3.9](https://quay.io/opendatahub-contrib/workbench-images:jupyter-monai-c9s-py39_2023b_latest)|quay.io/opendatahub-contrib/workbench-images:jupyter-monai-c9s-py39_2023b_latest|
+| Image description | Pull address                                                                         |
+|-------------------|--------------------------------------------------------------------------------------|
+|[Spark/PySpark 3.3.1 with Hadoop 3.3.4 based on jupyter-datascience-ubi9-py39](https://quay.io/opendatahub-contrib/workbench-images:jupyter-spark-ubi9-py39_2023b_latest)| quay.io/opendatahub-contrib/workbench-images:jupyter-spark-ubi9-py39_2023b_latest    |
+|[OptaPy based on jupyter-datascience-ubi9-py39](https://quay.io/opendatahub-contrib/workbench-images:jupyter-optapy-ubi9-py39_2023b_latest)| quay.io/opendatahub-contrib/workbench-images:jupyter-optapy-ubi9-py39_2023b_latest   |
+|[TrustyAI based on jupyter-datascience-ubi9-py39](https://quay.io/opendatahub-contrib/workbench-images:jupyter-trustyai-ubi9-py39_2023b_latest)| quay.io/opendatahub-contrib/workbench-images:jupyter-trustyai-ubi9-py39_2023b_latest |
+|[Monai JupyterLab Notebook image on Centos Stream 9 with Python 3.9](https://quay.io/opendatahub-contrib/workbench-images:jupyter-monai-c9s-py39_2023b_latest)| quay.io/opendatahub-contrib/workbench-images:jupyter-monai-c9s-py39_2023b_latest     |
 
 ### Runtimes
 


### PR DESCRIPTION
The current root level `Makefile` doesn't have a proper entry for the `push` command for the `trustyai` image.
This PR fixes this issue