### PR TITLE
Set $scheme correctly for redirects

### DIFF
--- a/snippets/ides/2-vscode/files/nginx/httpconf/http.conf
+++ b/snippets/ides/2-vscode/files/nginx/httpconf/http.conf
@@ -32,3 +32,8 @@ log_format json escape=json '[{'
     '"execution_state":"busy",'
     '"connections": 1'
     '}]';
+
+map $http_x_forwarded_proto $custom_scheme {
+        default $scheme;
+        https https;
+}

--- a/snippets/ides/2-vscode/files/nginx/serverconf/proxy.conf.template
+++ b/snippets/ides/2-vscode/files/nginx/serverconf/proxy.conf.template
@@ -16,7 +16,7 @@ location /api/ {
 # api calls from culler get to CGI processing
 ###############
 location = /api/kernels {
-    return 302 $scheme://$http_host/api/kernels/;
+    return 302 $custom_scheme://$http_host/api/kernels/;
     access_log  off;
 }
 
@@ -36,11 +36,11 @@ location /api/kernels/ {
 # root and prefix get to VSCode endpoint
 ###############
 location = / {
-    return 302 $scheme://$http_host/vscode/;
+    return 302 $custom_scheme://$http_host/vscode/;
 }
 
 location = /vscode {
-    return 302 $scheme://$http_host/vscode/;
+    return 302 $custom_scheme://$http_host/vscode/;
 }
 
 location /vscode/ {
@@ -54,6 +54,7 @@ location /vscode/ {
     # Needed to make it work properly
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $custom_scheme;
     proxy_set_header Host $http_host;
     proxy_set_header X-NginX-Proxy true;
     proxy_redirect off;

--- a/snippets/ides/2-vscode/files/nginx/serverconf/proxy.conf.template_nbprefix
+++ b/snippets/ides/2-vscode/files/nginx/serverconf/proxy.conf.template_nbprefix
@@ -16,12 +16,12 @@ location ${NB_PREFIX}/api/ {
 # api calls from culler get to CGI processing
 ###############
 location = ${NB_PREFIX}/api/kernels {
-    return 302 $scheme://$http_host/api/kernels/;
+    return 302 $custom_scheme://$http_host/api/kernels/;
     access_log  off;
 }
 
 location ${NB_PREFIX}/api/kernels/ {
-    return 302 $scheme://$http_host/api/kernels/;
+    return 302 $custom_scheme://$http_host/api/kernels/;
     access_log  off;
 }
 
@@ -41,19 +41,19 @@ location /api/kernels/ {
 # root and prefix get to VSCode endpoint
 ###############
 location = ${NB_PREFIX} {
-    return 302 $scheme://$http_host/vscode/;
+    return 302 $custom_scheme://$http_host/vscode/;
 }
 
 location ${NB_PREFIX}/ {
-    return 302 $scheme://$http_host/vscode/;
+    return 302 $custom_scheme://$http_host/vscode/;
 }
 
 location = /vscode {
-    return 302 $scheme://$http_host/vscode/;
+    return 302 $custom_scheme://$http_host/vscode/;
 }
 
 location = / {
-    return 302 $scheme://$http_host/vscode/;
+    return 302 $custom_scheme://$http_host/vscode/;
 }
 
 location /vscode/ {
@@ -64,6 +64,7 @@ location /vscode/ {
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;
     proxy_read_timeout 20d;
+    proxy_set_header X-Forwarded-Proto $custom_scheme;
 
     access_log /var/log/nginx/vscode.access.log json if=$loggable;
 }

--- a/snippets/ides/3-rstudio/files/nginx/httpconf/http.conf
+++ b/snippets/ides/3-rstudio/files/nginx/httpconf/http.conf
@@ -32,3 +32,8 @@ log_format json escape=json '[{'
     '"execution_state":"busy",'
     '"connections": 1'
     '}]';
+
+map $http_x_forwarded_proto $custom_scheme {
+        default $scheme;
+        https https;
+}

--- a/snippets/ides/3-rstudio/files/nginx/serverconf/proxy.conf.template
+++ b/snippets/ides/3-rstudio/files/nginx/serverconf/proxy.conf.template
@@ -1,8 +1,8 @@
 ###############
 # Fix rstudio-server auth-sign-in redirect bug
 ###############
-rewrite ^/auth-sign-in(.*) "$scheme://$http_host/rstudio/auth-sign-in$1?appUri=%2Frstudio";
-rewrite ^/auth-sign-out(.*) "$scheme://$http_host/rstudio/auth-sign-out$1?appUri=%2Frstudio";
+rewrite ^/auth-sign-in(.*) "$custom_scheme://$http_host/rstudio/auth-sign-in$1?appUri=%2Frstudio";
+rewrite ^/auth-sign-out(.*) "$custom_scheme://$http_host/rstudio/auth-sign-out$1?appUri=%2Frstudio";
 ###############
 
 ###############
@@ -20,7 +20,7 @@ location /api/ {
 }
 
 location = /api/kernels {
-    return 302 $scheme://$http_host/api/kernels/;
+    return 302 $custom_scheme://$http_host/api/kernels/;
     access_log  off;
 }
 
@@ -40,11 +40,11 @@ location /api/kernels/ {
 # api calls from culler get to CGI processing
 ###############
 location = / {
-    return 302 $scheme://$http_host/rstudio/;
+    return 302 $custom_scheme://$http_host/rstudio/;
 }
 
 location = /rstudio {
-    return 302 $scheme://$http_host/rstudio/;
+    return 302 $custom_scheme://$http_host/rstudio/;
 }
 
 location /rstudio/ {
@@ -57,9 +57,10 @@ location /rstudio/ {
     proxy_read_timeout 20d;
 
     # Needed to make it work properly
-    proxy_set_header X-RStudio-Request $scheme://$http_host$request_uri;
+    proxy_set_header X-RStudio-Request $custom_scheme://$http_host$request_uri;
     proxy_set_header X-RStudio-Root-Path /rstudio;
     proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-Proto $custom_scheme;
 
     access_log /var/log/nginx/rstudio.access.log json if=$loggable;
 }

--- a/snippets/ides/3-rstudio/files/nginx/serverconf/proxy.conf.template_nbprefix
+++ b/snippets/ides/3-rstudio/files/nginx/serverconf/proxy.conf.template_nbprefix
@@ -1,8 +1,8 @@
 ###############
 # Fix rstudio-server auth-sign-in redirect bug
 ###############
-rewrite ^/auth-sign-in(.*) "$scheme://$http_host/rstudio/auth-sign-in$1?appUri=%2Frstudio";
-rewrite ^/auth-sign-out(.*) "$scheme://$http_host/rstudio/auth-sign-out$1?appUri=%2Frstudio";
+rewrite ^/auth-sign-in(.*) "$custom_scheme://$http_host/rstudio/auth-sign-in$1?appUri=%2Frstudio";
+rewrite ^/auth-sign-out(.*) "$custom_scheme://$http_host/rstudio/auth-sign-out$1?appUri=%2Frstudio";
 ###############
 
 ###############
@@ -34,12 +34,12 @@ location /api/ {
 # api calls from culler get to CGI processing
 ###############
 location = ${NB_PREFIX}/api/kernels {
-    return 302 $scheme://$http_host/api/kernels/;
+    return 302 $custom_scheme://$http_host/api/kernels/;
     access_log  off;
 }
 
 location ${NB_PREFIX}/api/kernels/ {
-    return 302 $scheme://$http_host/api/kernels/;
+    return 302 $custom_scheme://$http_host/api/kernels/;
     access_log  off;
 }
 
@@ -59,19 +59,19 @@ location /api/kernels/ {
 # root and prefix get to RStudio endpoint
 ###############
 location = ${NB_PREFIX} {
-    return 302 $scheme://$http_host/rstudio/;
+    return 302 $custom_scheme://$http_host/rstudio/;
 }
 
 location ${NB_PREFIX}/ {
-    return 302 $scheme://$http_host/rstudio/;
+    return 302 $custom_scheme://$http_host/rstudio/;
 }
 
 location = /rstudio {
-    return 302 $scheme://$http_host/rstudio/;
+    return 302 $custom_scheme://$http_host/rstudio/;
 }
 
 location = / {
-    return 302 $scheme://$http_host/rstudio/;
+    return 302 $custom_scheme://$http_host/rstudio/;
 }
 
 location /rstudio/ {
@@ -84,9 +84,10 @@ location /rstudio/ {
     proxy_read_timeout 20d;
 
     # Needed to make it work properly
-    proxy_set_header X-RStudio-Request $scheme://$http_host$request_uri;
+    proxy_set_header X-RStudio-Request $custom_scheme://$http_host$request_uri;
     proxy_set_header X-RStudio-Root-Path /rstudio;
     proxy_set_header Host $http_host;
+    proxy_set_header X-Forwarded-Proto $custom_scheme;
 
     access_log /var/log/nginx/rstudio.access.log json if=$loggable;
 }

--- a/snippets/ides/4-langflow/files/nginx/httpconf/http.conf
+++ b/snippets/ides/4-langflow/files/nginx/httpconf/http.conf
@@ -32,3 +32,8 @@ log_format json escape=json '[{'
     '"execution_state":"busy",'
     '"connections": 1'
     '}]';
+
+map $http_x_forwarded_proto $custom_scheme {
+        default $scheme;
+        https https;
+}

--- a/snippets/ides/4-langflow/files/nginx/serverconf/proxy.conf.template
+++ b/snippets/ides/4-langflow/files/nginx/serverconf/proxy.conf.template
@@ -2,7 +2,7 @@
 # api calls from culler get to CGI processing
 ###############
 location = /api/kernels {
-    return 302 $scheme://$http_host/api/kernels/;
+    return 302 $custom_scheme://$http_host/api/kernels/;
     access_log  off;
 }
 
@@ -33,6 +33,7 @@ location / {
     # Needed to make it work properly
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $custom_scheme;
     proxy_set_header Host $http_host;
     proxy_set_header X-NginX-Proxy true;
     proxy_redirect off;

--- a/snippets/ides/4-langflow/files/nginx/serverconf/proxy.conf.template_nbprefix
+++ b/snippets/ides/4-langflow/files/nginx/serverconf/proxy.conf.template_nbprefix
@@ -2,12 +2,12 @@
 # api calls from culler get to CGI processing
 ###############
 location = ${NB_PREFIX}/api/kernels {
-    return 302 $scheme://$http_host/api/kernels/;
+    return 302 $custom_scheme://$http_host/api/kernels/;
     access_log  off;
 }
 
 location ${NB_PREFIX}/api/kernels/ {
-    return 302 $scheme://$http_host/api/kernels/;
+    return 302 $custom_scheme://$http_host/api/kernels/;
     access_log  off;
 }
 
@@ -27,17 +27,18 @@ location /api/kernels/ {
 # root and prefix get to Langflow endpoint
 ###############
 location = ${NB_PREFIX} {
-    return 302 $scheme://$http_host/;
+    return 302 $custom_scheme://$http_host/;
 }
 
 location ${NB_PREFIX}/ {
-    return 302 $scheme://$http_host/;
+    return 302 $custom_scheme://$http_host/;
 }
 
 location / {
     # Standard Langflow/NGINX configuration
     proxy_pass http://127.0.0.1:8787;
     proxy_http_version 1.1;
+    proxy_set_header X-Forwarded-Proto $custom_scheme;
     proxy_set_header Upgrade $http_upgrade;
     proxy_set_header Connection $connection_upgrade;
     proxy_read_timeout 20d;


### PR DESCRIPTION
Redirections to other locations were made to http, whatever the original scheme.
Route would take care of redirecting back to https, but this did not work when other proxies between browser and OpenShift would filter out any http traffic.
The patches make all redirections follow the original scheme, http or https.
Fixes #34
